### PR TITLE
Public playlists, Various fixes

### DIFF
--- a/backend/src/controllers/playlists.js
+++ b/backend/src/controllers/playlists.js
@@ -205,6 +205,10 @@ playlistsRouter.patch("/edit/:id", authenticateUser, async (req, res) => {
   }
 
   if("isPublic" in req.body) {
+    // stop making playlist private if there are followers that are not collaborators
+    if (!isPublic && playlist.followers.find(f => !f.isCollaborator && !f.isCreator)) {
+      return res.status(400).json({ error: "Cannot make playlist private: there are followers not collaborators" })
+    }
     playlist.isPublic = isPublic
   }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,22 +24,11 @@ import "../src/assets/styles/confirmationComponent.css"
 const App : FC = () => {
 
   const router = createBrowserRouter([
-    {
-      path: "/",
-      element: <Navigate to="/home" replace />
-    },
-    {
-      path: "/home",
-      element: <Sidebar sideContent={<SideContent />}><Home /></Sidebar>
-    },
-    {
-      path: "/login",
-      element: <Login />
-    },
-    {
-      path: "/register",
-      element: <Register />
-    },
+    { path: "/", element: <Navigate to="/home" replace /> },
+    { path: "/home", element: <Sidebar sideContent={<SideContent />}><Home /></Sidebar> },
+    { path: "/login", element: <Login /> },
+    { path: "/register", element: <Register /> },
+    { path: "explore/playlists", element: <Sidebar sideContent={<SideContent />}><ExplorePublicPlaylists /></Sidebar> },
     {
       path: "*",
       element: <ProtectedRoute><Sidebar sideContent={<SideContent />}><Outlet /></Sidebar></ProtectedRoute>,
@@ -47,7 +36,6 @@ const App : FC = () => {
         { path: "*", element: <Navigate to="/home" replace /> },
         { path: "explore/tracks", element: <ExploreTracks /> },
         { path: "explore/tracks/:trackId", element: <ExploreTracks /> },
-        { path: "explore/playlists", element: <ExplorePublicPlaylists /> },
         { path: "playlists", element: <Playlists /> },
         { path: "playlists/:id", element: <Playlist /> },
         { path: "playlists/create", element: <CreatePlaylist /> },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import EditProfile from "./components/Profile/EditProfile"
 import ProtectedRoute from "./components/ProtectedRoute"
 import Sidebar from "./components/Sidebar"
 import SideContent from "./components/SideContent"
+import ExplorePublicPlaylists from "./pages/ExplorePublicPlaylists"
 import ExploreTracks from "./pages/ExploreTracks"
 import Home from "./pages/Home"
 import Login from "./pages/Login"
@@ -46,6 +47,7 @@ const App : FC = () => {
         { path: "*", element: <Navigate to="/home" replace /> },
         { path: "explore/tracks", element: <ExploreTracks /> },
         { path: "explore/tracks/:trackId", element: <ExploreTracks /> },
+        { path: "explore/playlists", element: <ExplorePublicPlaylists /> },
         { path: "playlists", element: <Playlists /> },
         { path: "playlists/:id", element: <Playlist /> },
         { path: "playlists/create", element: <CreatePlaylist /> },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,7 +9,7 @@ import EditProfile from "./components/Profile/EditProfile"
 import ProtectedRoute from "./components/ProtectedRoute"
 import Sidebar from "./components/Sidebar"
 import SideContent from "./components/SideContent"
-import Explore from "./pages/Explore"
+import ExploreTracks from "./pages/ExploreTracks"
 import Home from "./pages/Home"
 import Login from "./pages/Login"
 import Playlists from "./pages/Playlists"
@@ -44,8 +44,8 @@ const App : FC = () => {
       element: <ProtectedRoute><Sidebar sideContent={<SideContent />}><Outlet /></Sidebar></ProtectedRoute>,
       children: [
         { path: "*", element: <Navigate to="/home" replace /> },
-        { path: "explore", element: <Explore /> },
-        { path: "explore/:trackId", element: <Explore /> },
+        { path: "explore/tracks", element: <ExploreTracks /> },
+        { path: "explore/tracks/:trackId", element: <ExploreTracks /> },
         { path: "playlists", element: <Playlists /> },
         { path: "playlists/:id", element: <Playlist /> },
         { path: "playlists/create", element: <CreatePlaylist /> },

--- a/frontend/src/components/Explore/OpenTrack.tsx
+++ b/frontend/src/components/Explore/OpenTrack.tsx
@@ -19,7 +19,7 @@ const OpenTrack : FC<{
   const navigate = useNavigate()
 
   const handleClose = () => {
-    navigate("/explore")
+    navigate("/explore/tracks")
     setOpenTrack(undefined)
   }
 

--- a/frontend/src/components/Explore/Recommendations.tsx
+++ b/frontend/src/components/Explore/Recommendations.tsx
@@ -90,7 +90,7 @@ const Recommendations : FC<{customClasses ?: string}> = ({ customClasses }) => {
 
   return (
     <div className={`relative w-full flex items-center overflow-x-auto ${customClasses}`}>
-      {tracks?.map(t => <TrackCard key={t.id} track={t} onclick={() => {navigate(`/explore/${t.id}`)}} />)}
+      {tracks?.map(t => <TrackCard key={t.id} track={t} onclick={() => {navigate(`/explore/tracks/${t.id}`)}} />)}
     </div>
   )
 }

--- a/frontend/src/components/Explore/Recommendations.tsx
+++ b/frontend/src/components/Explore/Recommendations.tsx
@@ -33,13 +33,13 @@ const Recommendations : FC<{customClasses ?: string}> = ({ customClasses }) => {
             // in home display only expired
             if (type === "expired") {
               toast.error(message)
-              navigate("/login")
+              navigate("/login", { replace: true })
             }
           }
           // not in home display all errors
           else {
             toast.error(message)
-            navigate("/login")
+            navigate("/login", { replace: true })
           }
 
           return

--- a/frontend/src/components/Explore/SearchBox.tsx
+++ b/frontend/src/components/Explore/SearchBox.tsx
@@ -60,7 +60,7 @@ const SearchBox : FC<{
         const { valid, message } = checkTokenExpiration()
         if (!valid) {
           toast.error(message)
-          navigate("/login")
+          navigate("/login", { replace: true })
           return
         }
 

--- a/frontend/src/components/Explore/SearchBox.tsx
+++ b/frontend/src/components/Explore/SearchBox.tsx
@@ -10,9 +10,9 @@ import checkTokenExpiration from "../../utils/checkTokenExpiration"
 import REGEX from "../../utils/regex"
 import Loading from "../Loading"
 
-import Filters from "./Filters"
 import Recommendations from "./Recommendations"
 import TrackCard from "./TrackCard"
+import TrackFilters from "./TrackFilters"
 
 const SearchBox : FC<{
   isLoading : boolean,
@@ -110,7 +110,7 @@ const SearchBox : FC<{
           {filtersOpen ? <MdExpandLess className="inline -mt-1" /> : <MdExpandMore className="inline -mt-1" />}
         </h2>
 
-        {filtersOpen && <Filters
+        {filtersOpen && <TrackFilters
           artist={artist}
           setArtist={setArtist}
           genre={genre}

--- a/frontend/src/components/Explore/SearchBox.tsx
+++ b/frontend/src/components/Explore/SearchBox.tsx
@@ -137,7 +137,7 @@ const SearchBox : FC<{
               track={t}
               key={t.id}
               openTrack={openTrack}
-              onclick={() => navigate(`/explore/${t.id}`)}
+              onclick={() => navigate(`/explore/tracks/${t.id}`)}
             />
           )}
         </div>

--- a/frontend/src/components/Explore/TrackFilters.tsx
+++ b/frontend/src/components/Explore/TrackFilters.tsx
@@ -4,7 +4,7 @@ import MultiRangeSlider from "multi-range-slider-react"
 
 import "../../assets/styles/sliderComponent.css"
 
-const Filters : FC<{
+const TrackFilters : FC<{
   artist : string,
   setArtist : (a : string) => void,
   genre : string,
@@ -61,4 +61,4 @@ const Filters : FC<{
   )
 }
 
-export default Filters
+export default TrackFilters

--- a/frontend/src/components/Playlists/AddToPlaylist.tsx
+++ b/frontend/src/components/Playlists/AddToPlaylist.tsx
@@ -37,7 +37,7 @@ const AddToPlaylist : FC<{
         const { valid, message } = checkTokenExpiration()
         if (!valid) {
           toast.error(message)
-          navigate("/login")
+          navigate("/login", { replace: true })
           return
         }
 
@@ -81,7 +81,7 @@ const AddToPlaylist : FC<{
       const { valid, message } = checkTokenExpiration()
       if (!valid) {
         toast.error(message)
-        navigate("/login")
+        navigate("/login", { replace: true })
         return
       }
 

--- a/frontend/src/components/Playlists/CreatePlaylist.tsx
+++ b/frontend/src/components/Playlists/CreatePlaylist.tsx
@@ -58,7 +58,7 @@ const CreatePlaylist : FC = () => {
       const { valid, message } = checkTokenExpiration()
       if (!valid) {
         toast.error(message)
-        navigate("/login")
+        navigate("/login", { replace: true })
         return
       }
 

--- a/frontend/src/components/Playlists/EditPlaylist.tsx
+++ b/frontend/src/components/Playlists/EditPlaylist.tsx
@@ -41,7 +41,7 @@ const EditPlaylist : FC = () => {
         const { valid, message } = checkTokenExpiration()
         if (!valid) {
           toast.error(message)
-          navigate("/login")
+          navigate("/login", { replace: true })
           return
         }
 
@@ -98,7 +98,7 @@ const EditPlaylist : FC = () => {
       const { valid, message } = checkTokenExpiration()
       if (!valid) {
         toast.error(message)
-        navigate("/login")
+        navigate("/login", { replace: true })
         return
       }
 

--- a/frontend/src/components/Playlists/Followers.tsx
+++ b/frontend/src/components/Playlists/Followers.tsx
@@ -30,7 +30,7 @@ const Followers : FC<{
         const { valid, message } = checkTokenExpiration()
         if (!valid) {
           toast.error(message)
-          navigate("/login")
+          navigate("/login", { replace: true })
           return
         }
 
@@ -62,7 +62,7 @@ const Followers : FC<{
       const { valid, message } = checkTokenExpiration()
       if (!valid) {
         toast.error(message)
-        navigate("/login")
+        navigate("/login", { replace: true })
         return
       }
 
@@ -96,7 +96,7 @@ const Followers : FC<{
       const { valid, message } = checkTokenExpiration()
       if (!valid) {
         toast.error(message)
-        navigate("/login")
+        navigate("/login", { replace: true })
         return
       }
 

--- a/frontend/src/components/Playlists/Playlist.tsx
+++ b/frontend/src/components/Playlists/Playlist.tsx
@@ -36,7 +36,7 @@ const Playlist : FC = () => {
         const { valid, message } = checkTokenExpiration()
         if (!valid) {
           toast.error(message)
-          navigate("/login")
+          navigate("/login", { replace: true })
           return
         }
 
@@ -93,7 +93,7 @@ const Playlist : FC = () => {
       const { valid, message } = checkTokenExpiration()
       if (!valid) {
         toast.error(message)
-        navigate("/login")
+        navigate("/login",  { replace: true })
         return
       }
 
@@ -125,7 +125,7 @@ const Playlist : FC = () => {
       const { valid, message } = checkTokenExpiration()
       if (!valid) {
         toast.error(message)
-        navigate("/login")
+        navigate("/login",  { replace: true })
         return
       }
 
@@ -160,7 +160,7 @@ const Playlist : FC = () => {
       const { valid, message } = checkTokenExpiration()
       if (!valid) {
         toast.error(message)
-        navigate("/login")
+        navigate("/login",  { replace: true })
         return
       }
 

--- a/frontend/src/components/Playlists/PlaylistFilters.tsx
+++ b/frontend/src/components/Playlists/PlaylistFilters.tsx
@@ -1,0 +1,62 @@
+import type { FC } from "react"
+
+const TrackFilters : FC<{
+  title : string,
+  setTitle : (a : string) => void,
+  author : string,
+  setAuthor : (g : string) => void,
+  tag : string,
+  setTag : (t : string) => void,
+  track : string,
+  setTrack : (t : string) => void
+}> = ({ title, setTitle, author, setAuthor, tag, setTag, track, setTrack }) => (
+  <div className="grid grid-cols-2 gap-2">
+
+    <div className="flex flex-col items-center">
+      <h3 className="text-center font-semibold italic">Playlist title:</h3>
+      <input
+        type="text"
+        placeholder="Title"
+        value={title}
+        onChange={({ target }) => { setTitle(target.value) }}
+        className="w-[200px] text-white bg-white/20 border-2 border-transparent py-2 px-3 rounded-md leading-tight outline-none placeholder:text-gray-400 focus-within:border-spotify-green transition-all duration-700"
+      />
+    </div>
+
+    <div className="flex flex-col items-center">
+      <h3 className="text-center font-semibold italic">Playlist author:</h3>
+      <input
+        type="text"
+        placeholder="Author"
+        value={author}
+        onChange={({ target }) => { setAuthor(target.value) }}
+        className="w-[200px] text-white bg-white/20 border-2 border-transparent py-2 px-3 rounded-md leading-tight outline-none placeholder:text-gray-400 focus-within:border-spotify-green transition-all duration-700"
+      />
+    </div>
+
+    <div className="flex flex-col items-center">
+      <h3 className="text-center font-semibold italic">Playlist tag:</h3>
+      <input
+        type="text"
+        placeholder="Tag"
+        value={tag}
+        onChange={({ target }) => { setTag(target.value) }}
+        className="w-[200px] text-white bg-white/20 border-2 border-transparent py-2 px-3 rounded-md leading-tight outline-none placeholder:text-gray-400 focus-within:border-spotify-green transition-all duration-700"
+      />
+    </div>
+
+    <div className="flex flex-col items-center">
+      <h3 className="text-center font-semibold italic">Track contained in playlist:</h3>
+      <input
+        type="text"
+        placeholder="Track"
+        value={track}
+        onChange={({ target }) => { setTrack(target.value) }}
+        className="w-[200px] text-white bg-white/20 border-2 border-transparent py-2 px-3 rounded-md leading-tight outline-none placeholder:text-gray-400 focus-within:border-spotify-green transition-all duration-700"
+      />
+    </div>
+
+  </div>
+)
+
+export default TrackFilters

--- a/frontend/src/components/Playlists/TrackRow.tsx
+++ b/frontend/src/components/Playlists/TrackRow.tsx
@@ -54,7 +54,7 @@ const TrackRow : FC<{
       const { valid, message } = checkTokenExpiration()
       if (!valid) {
         toast.error(message)
-        navigate("/login")
+        navigate("/login",  { replace: true })
         return
       }
 

--- a/frontend/src/components/Playlists/UserPlaylists.tsx
+++ b/frontend/src/components/Playlists/UserPlaylists.tsx
@@ -28,7 +28,7 @@ const UserPlaylists : FC = () => {
         const { valid, message } = checkTokenExpiration()
         if (!valid) {
           toast.error(message)
-          navigate("/login")
+          navigate("/login", { replace: true })
           return
         }
 

--- a/frontend/src/components/Profile/DeleteAccount.tsx
+++ b/frontend/src/components/Profile/DeleteAccount.tsx
@@ -53,7 +53,7 @@ const DeleteAccount : FC<{
       const { valid, message } = checkTokenExpiration()
       if (!valid) {
         toast.error(message)
-        navigate("/login")
+        navigate("/login",  { replace: true })
         return
       }
 

--- a/frontend/src/components/Profile/EditFavouriteArtists.tsx
+++ b/frontend/src/components/Profile/EditFavouriteArtists.tsx
@@ -49,7 +49,7 @@ const EditFavourites : FC<{handleAdd : (o : Option) => void}> = ({ handleAdd }) 
       const { valid, message } = checkTokenExpiration()
       if (!valid) {
         toast.error(message)
-        navigate("/login")
+        navigate("/login",  { replace: true })
         return
       }
 

--- a/frontend/src/components/Profile/EditFavouriteGenres.tsx
+++ b/frontend/src/components/Profile/EditFavouriteGenres.tsx
@@ -32,7 +32,7 @@ const EditFavourites : FC<{handleAdd : (o : Option) => void}> = ({ handleAdd }) 
         const { valid, message } = checkTokenExpiration()
         if (!valid) {
           toast.error(message)
-          navigate("/login")
+          navigate("/login", { replace: true })
           return
         }
 

--- a/frontend/src/components/Profile/EditProfile.tsx
+++ b/frontend/src/components/Profile/EditProfile.tsx
@@ -37,7 +37,7 @@ const EditProfile : FC = () => {
         const { valid, message } = checkTokenExpiration()
         if (!valid) {
           toast.error(message)
-          navigate("/login")
+          navigate("/login", { replace: true })
           return
         }
 
@@ -97,7 +97,7 @@ const EditProfile : FC = () => {
       const { valid, message } = checkTokenExpiration()
       if (!valid) {
         toast.error(message)
-        navigate("/login")
+        navigate("/login",  { replace: true })
         return
       }
 

--- a/frontend/src/components/Profile/FavouriteArtists.tsx
+++ b/frontend/src/components/Profile/FavouriteArtists.tsx
@@ -59,7 +59,7 @@ const FavouriteArtists : FC<{
       const { valid, message } = checkTokenExpiration()
       if (!valid) {
         toast.error(message)
-        navigate("/login")
+        navigate("/login",  { replace: true })
         return
       }
 

--- a/frontend/src/components/Profile/FavouriteGenres.tsx
+++ b/frontend/src/components/Profile/FavouriteGenres.tsx
@@ -58,7 +58,7 @@ const FavouriteGenres : FC<{
       const { valid, message } = checkTokenExpiration()
       if (!valid) {
         toast.error(message)
-        navigate("/login")
+        navigate("/login",  { replace: true })
         return
       }
 

--- a/frontend/src/components/SideContent.tsx
+++ b/frontend/src/components/SideContent.tsx
@@ -10,6 +10,7 @@ const SideContent : FC = () => {
   const links = [
     { to: "/home", text: "Homepage" },
     { to: "/explore/tracks", text: "Explore tracks" },
+    { to: "/explore/playlists", text: "Public playlists" },
     { to: "/playlists", text: "My Playlists" }
   ]
 

--- a/frontend/src/components/SideContent.tsx
+++ b/frontend/src/components/SideContent.tsx
@@ -9,7 +9,7 @@ const SideContent : FC = () => {
 
   const links = [
     { to: "/home", text: "Homepage" },
-    { to: "/explore", text: "Explore" },
+    { to: "/explore/tracks", text: "Explore tracks" },
     { to: "/playlists", text: "My Playlists" }
   ]
 

--- a/frontend/src/pages/ExplorePublicPlaylists.tsx
+++ b/frontend/src/pages/ExplorePublicPlaylists.tsx
@@ -1,0 +1,133 @@
+import type { FC } from "react"
+import { useEffect, useState } from "react"
+import { FaPlus } from "react-icons/fa"
+import { MdExpandLess, MdExpandMore } from "react-icons/md"
+import { Link } from "react-router-dom"
+import { toast } from "react-toastify"
+
+import Loading from "../components/Loading"
+import PlaylistCard from "../components/Playlists/PlaylistCard"
+import PlaylistFilters from "../components/Playlists/PlaylistFilters"
+import type Playlist from "../interfaces/Playlist"
+import playlistsService from "../services/playlists"
+
+const PublicPlaylists : FC = () => {
+
+  const [isLoading, setIsLoading] = useState<boolean>(true)
+
+  const [playlists, setPlaylists] = useState<Playlist[]>([])
+  const [filteredPlaylists, setFilteredPlaylists] = useState<Playlist[]>([])
+
+  const [filtersOpen, setFiltersOpen] = useState<boolean>(false)
+
+  const [title, setTitle] = useState<string>("")
+  const [author, setAuthor] = useState<string>("")
+  const [tag, setTag] = useState<string>("")
+  const [track, setTrack] = useState<string>("")
+
+  useEffect(() => {
+
+    const fetchData = async () => {
+      setIsLoading(true)
+
+      try {
+        const res = await playlistsService.getPublic()
+
+        setPlaylists(res.sort((a : Playlist, b : Playlist) => b.followers.length - a.followers.length))
+      }
+      catch(e) {
+        if (e?.response?.data?.error) {
+          toast.error(e.response.data.error)
+        } else {
+          toast.error("Generic error, please try again")
+        }
+      }
+      finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchData()
+
+  }, [])
+
+  useEffect(() => {
+    setFilteredPlaylists(playlists.filter(p => {
+      if (title) {
+        if (!p.title.match(new RegExp(title, "i"))) return false
+      }
+
+      if (author) {
+        if (!p.creator.match(new RegExp(author, "i"))) return false
+      }
+
+      if (tag) {
+        if (!p.tags.find(t => t.match(new RegExp(tag, "i")))) return false
+      }
+
+      if (track) {
+        if (!p.tracks.find(t => t.name.match(new RegExp(track, "i")))) return false
+      }
+
+      return true
+    }))
+  }, [playlists, title, author, tag, track])
+
+  return (
+    <div className="relative w-full h-full border border-white/20 rounded-md p-6 flex flex-col justify-center items-center">
+      {isLoading && <Loading small />}
+
+      <h1 className="text-xl font-bold">{playlists.length} public <span className="text-spotify-green">playlists</span> found</h1>
+      <h1 className="text-llg font-semibold text-white/70">Displaying {filteredPlaylists.length} <span className="text-spotify-green">filtered</span> playlists</h1>
+
+      <h2
+        onClick={() => setFiltersOpen(!filtersOpen)}
+        className="text-lg font-bold my-2 cursor-pointer"
+      >
+        {filtersOpen ? <MdExpandLess className="inline -mt-1" /> : <MdExpandMore className="inline -mt-1" />}
+          Advanced filters
+        {filtersOpen ? <MdExpandLess className="inline -mt-1" /> : <MdExpandMore className="inline -mt-1" />}
+      </h2>
+
+      {filtersOpen && <PlaylistFilters
+        title={title}
+        setTitle={setTitle}
+        author={author}
+        setAuthor={setAuthor}
+        tag={tag}
+        setTag={setTag}
+        track={track}
+        setTrack={setTrack}
+      />}
+
+      {playlists.length === 0
+        ?
+        <div className="relative w-full h-full flex items-center justify-center">
+          <h3 className="-mt-10 text-xl text-white/80 font-bold">
+            <>No public playlists found. </>
+            <Link to="/playlists/create" className="underline text-spotify-green">Create new playlist!</Link>
+          </h3>
+        </div>
+        :
+        filteredPlaylists.length === 0
+          ?
+          <div className="relative w-full h-full flex items-center justify-center">
+            <h3 className="-mt-10 text-xl text-white/80 font-bold">
+              <>No playlists matching these <span className="text-spotify-green">filters</span> found. </>
+            </h3>
+          </div>
+          :
+          <div className="relative w-full h-full flex items-center overflow-x-auto">
+            {filteredPlaylists?.map(p => <PlaylistCard key={p._id} p={p} />)}
+          </div>
+      }
+
+      <Link
+        to="/playlists/create"
+        className="absolute bottom-10 left-1/2 -translate-x-1/2 -skew-y-2 text-xl uppercase bg-spotify-green hover:bg-spotify-greendark text-white font-bold py-2 px-4 rounded-md transition-all duration-700 z-10"
+      ><FaPlus className="inline -mt-1 mr-2 text-xl" />New playlist</Link>
+    </div>
+  )
+}
+
+export default PublicPlaylists

--- a/frontend/src/pages/ExploreTracks.tsx
+++ b/frontend/src/pages/ExploreTracks.tsx
@@ -26,7 +26,7 @@ const ExploreTracks : FC = () => {
         const { valid, message } = checkTokenExpiration()
         if (!valid) {
           toast.error(message)
-          navigate("/login")
+          navigate("/login", { replace: true })
           return
         }
 

--- a/frontend/src/pages/ExploreTracks.tsx
+++ b/frontend/src/pages/ExploreTracks.tsx
@@ -9,7 +9,7 @@ import type Track from "../interfaces/Track"
 import spotifyService from "../services/spotify"
 import checkTokenExpiration from "../utils/checkTokenExpiration"
 
-const Explore : FC = () => {
+const ExploreTracks : FC = () => {
 
   const { trackId } = useParams()
   const navigate = useNavigate()
@@ -72,4 +72,4 @@ const Explore : FC = () => {
   )
 }
 
-export default Explore
+export default ExploreTracks

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,5 +1,6 @@
 import type { FC } from "react"
-import { Navigate } from "react-router-dom"
+import { IoIosArrowBack } from "react-icons/io"
+import { Link, Navigate } from "react-router-dom"
 
 import LoginForm from "../components/Login/LoginForm"
 import useAuth from "../hooks/useAuth"
@@ -13,7 +14,12 @@ const Login : FC = () => {
   }
 
   return (
-    <div className="w-screen h-screen flex items-center justify-center">
+    <div className="relative w-screen h-screen flex items-center justify-center">
+
+      <Link to="/home" className="absolute top-6 left-5 uppercase italic hover:text-white/80">
+        <IoIosArrowBack className="inline text-2xl -mt-1" />Home
+      </Link>
+
       <LoginForm />
     </div>
   )

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -28,7 +28,7 @@ const Profile : FC = () => {
         const { valid, message } = checkTokenExpiration()
         if (!valid) {
           toast.error(message)
-          navigate("/login")
+          navigate("/login", { replace: true })
           return
         }
 

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -1,5 +1,6 @@
 import type { FC } from "react"
-import { Navigate } from "react-router-dom"
+import { IoIosArrowBack } from "react-icons/io"
+import { Link, Navigate } from "react-router-dom"
 
 import RegisterForm from "../components/Login/RegisterForm"
 import useAuth from "../hooks/useAuth"
@@ -14,6 +15,11 @@ const Register : FC = () => {
 
   return (
     <div className="w-screen h-screen flex items-center justify-center">
+
+      <Link to="/login" className="absolute top-6 left-5 uppercase italic hover:text-white/80">
+        <IoIosArrowBack className="inline text-2xl -mt-1" />Login
+      </Link>
+
       <RegisterForm />
     </div>
   )


### PR DESCRIPTION
Public playlists:
- add `/explore/playlists` routing
- add `PlaylistFilters` component
- add `ExplorePublicPlaylists` page
- make `/explore/playlists` not protected route

Various:
- fix making playlists private in `playlists` controller (cannot make playlist private if followers not collaborators)
- rename `Explore` to `ExploreTracks`
- rename `Filters` to `TrackFilters`
- add go back link in `Login`, `Register`
- add `replace` to `checkTokenExpiration` redirect (to prevent infinite loop in paths history)