### PR TITLE
Navigate refactor

### DIFF
--- a/frontend/src/components/Explore/OpenTrack.tsx
+++ b/frontend/src/components/Explore/OpenTrack.tsx
@@ -40,13 +40,11 @@ const OpenTrack : FC<{
 
       <div className="mt-4 text-center bg-spotify-greendark rounded-md font-bold px-4 py-1">
         {track.artists.map((a, i) =>
-          <h2
-            onClick={() => navigate("/explore/tracks", { state: { redirectArtist: a.name } })}
-            key={a.id}
-            className="cursor-pointer hover:underline uppercase px-2 text-ellipsis whitespace-nowrap overflow-hidden"
-          >
-            {a.name}{i < track.artists.length - 1 ? ", " : ""}
-          </h2>
+          <Link to="/explore/tracks" state={{ redirectArtist: a.name }} key={a.id}>
+            <h2 className="cursor-pointer hover:underline uppercase px-2 text-ellipsis whitespace-nowrap overflow-hidden">
+              {a.name}{i < track.artists.length - 1 ? ", " : ""}
+            </h2>
+          </Link>
         )}
       </div>
 

--- a/frontend/src/components/Explore/OpenTrack.tsx
+++ b/frontend/src/components/Explore/OpenTrack.tsx
@@ -3,6 +3,7 @@ import { BsSpotify } from "react-icons/bs"
 import { IoCloseSharp } from "react-icons/io5"
 import { Link, useNavigate } from "react-router-dom"
 
+import playlistImg from "../../assets/images/playlist-placeholder.webp"
 import type Track from "../../interfaces/Track"
 import parseTime from "../../utils/parseTime"
 import Loading from "../Loading"
@@ -32,7 +33,7 @@ const OpenTrack : FC<{
         className="absolute -top-2 -left-2 md:left-auto md:top-2 md:right-2 h-6 w-6 cursor-pointer"
       />
 
-      <img src={track.album.images[0].url} className="w-72 h-72 rounded-md" />
+      <img src={track.album.images[0]?.url ?? playlistImg} className="w-72 h-72 rounded-md" />
 
       <h1 className="mt-4 text-2xl font-bold">{track.name}</h1>
 

--- a/frontend/src/components/Explore/Recommendations.tsx
+++ b/frontend/src/components/Explore/Recommendations.tsx
@@ -90,7 +90,11 @@ const Recommendations : FC<{customClasses ?: string}> = ({ customClasses }) => {
 
   return (
     <div className={`relative ${customClasses}`}>
-      {tracks?.map(t => <TrackCard key={t.id} track={t} onclick={() => {navigate(`/explore/tracks/${t.id}`)}} />)}
+      {tracks?.map(t =>
+        <Link key={t.id} to={`/explore/tracks/${t.id}`}>
+          <TrackCard track={t} />
+        </Link>
+      )}
     </div>
   )
 }

--- a/frontend/src/components/Explore/SearchBox.tsx
+++ b/frontend/src/components/Explore/SearchBox.tsx
@@ -1,7 +1,7 @@
 import type { FC } from "react"
 import { useEffect, useState } from "react"
 import { MdExpandLess, MdExpandMore } from "react-icons/md"
-import { useLocation, useNavigate } from "react-router-dom"
+import { Link, useLocation, useNavigate } from "react-router-dom"
 import { toast } from "react-toastify"
 
 import type Track from "../../interfaces/Track"
@@ -153,12 +153,12 @@ const SearchBox : FC<{
         <div className="relative w-full h-full mt-2 flex flex-wrap justify-center items-center overflow-y-auto">
           {isLoading && <Loading small={true} />}
           {tracks.map(t =>
-            <TrackCard
-              track={t}
-              key={t.id}
-              openTrack={openTrack}
-              onclick={() => navigate(`/explore/tracks/${t.id}`)}
-            />
+            <Link to={`/explore/tracks/${t.id}`} key={t.id}>
+              <TrackCard
+                track={t}
+                openTrack={openTrack}
+              />
+            </Link>
           )}
         </div>
       }

--- a/frontend/src/components/Explore/TrackCard.tsx
+++ b/frontend/src/components/Explore/TrackCard.tsx
@@ -1,5 +1,6 @@
 import type { FC } from "react"
 
+import playlistImg from "../../assets/images/playlist-placeholder.webp"
 import type Track from "../../interfaces/Track"
 
 const TrackCard : FC<{
@@ -10,7 +11,7 @@ const TrackCard : FC<{
   <div
     className={`${openTrack?.id === track.id ? "bg-white/20 border-spotify-greendark" : ""} -skew-y-2 shrink-0 grow-0 m-4 w-28 md:w-40 pb-2 h-48 md:h-60 flex flex-col items-center border border-white/20 rounded-md text-center hover:bg-white/20 cursor-pointer transition-all duration-700`}>
 
-    <img src={track.album.images[0].url} className="w-28 h-28 md:w-40 md:h-40 rounded-t-md opacity-80" />
+    <img src={track.album.images[0]?.url ?? playlistImg} className="w-28 h-28 md:w-40 md:h-40 rounded-t-md opacity-80" />
 
     <h1 className="w-full my-1 px-2 font-bold text-ellipsis whitespace-nowrap overflow-hidden">{track.name}</h1>
 

--- a/frontend/src/components/Explore/TrackCard.tsx
+++ b/frontend/src/components/Explore/TrackCard.tsx
@@ -4,12 +4,10 @@ import type Track from "../../interfaces/Track"
 
 const TrackCard : FC<{
   track : Track,
-  openTrack ?: Track,
-  onclick : ((t : Track) => void)
-}> = ({ track, openTrack, onclick }) => (
+  openTrack ?: Track
+}> = ({ track, openTrack }) => (
 
   <div
-    onClick={() => onclick(track)}
     className={`${openTrack?.id === track.id ? "bg-white/20 border-spotify-greendark" : ""} -skew-y-2 shrink-0 grow-0 m-4 w-28 md:w-40 pb-2 h-48 md:h-60 flex flex-col items-center border border-white/20 rounded-md text-center hover:bg-white/20 cursor-pointer transition-all duration-700`}>
 
     <img src={track.album.images[0].url} className="w-28 h-28 md:w-40 md:h-40 rounded-t-md opacity-80" />

--- a/frontend/src/components/Playlists/Playlist.tsx
+++ b/frontend/src/components/Playlists/Playlist.tsx
@@ -212,11 +212,11 @@ const Playlist : FC = () => {
 
         <div className="mt-2 shrink-0 w-full flex flex-row flex-wrap justify-center">
           {playlist.tags.map(t =>
-            <h3
-              onClick={() => navigate("/explore/playlists", { state: { redirectTag: t } })}
-              key={t}
-              className="cursor-pointer hover:underline bg-gray-500/40 inline m-1 rounded px-2 py-0.5"
-            >{t}</h3>
+            <Link to="/explore/playlists" state={{ redirectTag: t }} key={t}>
+              <h3 className="cursor-pointer hover:underline bg-gray-500/40 inline m-1 rounded px-2 py-0.5">
+                {t}
+              </h3>
+            </Link>
           )}
         </div>
 

--- a/frontend/src/components/Playlists/PlaylistImage.tsx
+++ b/frontend/src/components/Playlists/PlaylistImage.tsx
@@ -15,7 +15,7 @@ const PlaylistImage : FC<{tracks : Track[], customClasses : string}> = ({ tracks
   // only one track: track image
   if (tracks.length === 1) {
     return (
-      <img src={tracks[0].album.images[0].url} className={`${customClasses} opacity-60 saturate-[0.8]`} />
+      <img src={tracks[0].album.images[0]?.url ?? placeholderImg} className={`${customClasses} opacity-60 saturate-[0.8]`} />
     )
   }
 
@@ -23,8 +23,8 @@ const PlaylistImage : FC<{tracks : Track[], customClasses : string}> = ({ tracks
   if (tracks.length < 4) {
     return (
       <div className={`${customClasses} grid grid-rows-1 grid-cols-2 opacity-60 saturate-[0.8] overflow-hidden`}>
-        <img src={tracks[0].album.images[0].url} className="h-full object-cover" />
-        <img src={tracks[1].album.images[0].url} className="h-full object-cover" />
+        <img src={tracks[0].album.images[0]?.url ?? placeholderImg} className="h-full object-cover" />
+        <img src={tracks[1].album.images[0]?.url ?? placeholderImg} className="h-full object-cover" />
       </div>
     )
   }
@@ -32,10 +32,10 @@ const PlaylistImage : FC<{tracks : Track[], customClasses : string}> = ({ tracks
   // 4 or more tracks: first 4 tracks images
   return (
     <div className={`${customClasses} grid grid-rows-2 grid-cols-2 opacity-60 saturate-[0.8] overflow-hidden`}>
-      <img src={tracks[0].album.images[0].url} />
-      <img src={tracks[1].album.images[0].url} />
-      <img src={tracks[2].album.images[0].url} />
-      <img src={tracks[3].album.images[0].url} />
+      <img src={tracks[0].album.images[0]?.url ?? placeholderImg} />
+      <img src={tracks[1].album.images[0]?.url ?? placeholderImg} />
+      <img src={tracks[2].album.images[0]?.url ?? placeholderImg} />
+      <img src={tracks[3].album.images[0]?.url ?? placeholderImg} />
     </div>
   )
 }

--- a/frontend/src/components/Playlists/TrackRow.tsx
+++ b/frontend/src/components/Playlists/TrackRow.tsx
@@ -8,6 +8,7 @@ import { MdPlayDisabled, MdPlaylistAdd } from "react-icons/md"
 import { Link, useNavigate } from "react-router-dom"
 import { toast } from "react-toastify"
 
+import placeholderImg from "../../assets/images/playlist-placeholder.webp"
 import type Playlist from "../../interfaces/Playlist"
 import type Track from "../../interfaces/Track"
 import playlistsService from "../../services/playlists"
@@ -90,7 +91,7 @@ const TrackRow : FC<{
           : <MdPlayDisabled title="Preview unavailable" className="inline w-10 text-2xl mr-3 text-white/20" />
         }
 
-        <img src={track.album.images[0].url} className="w-16 h-16 opacity-80" />
+        <img src={track.album.images[0]?.url ?? placeholderImg} className="w-16 h-16 opacity-80" />
 
         <div className="w-full flex flex-col items-center px-2">
           <h1 className="w-full font-bold text-ellipsis whitespace-nowrap overflow-hidden">{track.name}</h1>

--- a/frontend/src/components/Playlists/TrackRow.tsx
+++ b/frontend/src/components/Playlists/TrackRow.tsx
@@ -5,7 +5,7 @@ import { BiAlbum } from "react-icons/bi"
 import { FiClock } from "react-icons/fi"
 import { ImBin2 } from "react-icons/im"
 import { MdPlayDisabled, MdPlaylistAdd } from "react-icons/md"
-import { useNavigate } from "react-router-dom"
+import { Link, useNavigate } from "react-router-dom"
 import { toast } from "react-toastify"
 
 import type Playlist from "../../interfaces/Playlist"
@@ -98,13 +98,13 @@ const TrackRow : FC<{
           <div className="w-full overflow-hidden">
             {track.explicit && <h2 title="Explicit" className="inline text-red-700 text-xs uppercase border border-red-700 px-1 pb-0.5 rounded opacity-70 mr-1">E</h2>}
             {track.artists.map((a, i) =>
-              <h2
-                onClick={() => navigate("/explore/tracks", { state: { redirectArtist: a.name } })}
-                key={a.id}
-                className="cursor-pointer hover:underline inline uppercase text-sm text-ellipsis whitespace-nowrap overflow-hidden"
-              >
-                {a.name}{i < track.artists.length - 1 ? ", " : ""}
-              </h2>
+              <Link to="/explore/tracks" state={{ redirectArtist: a.name }} key={a.id}>
+                <h2
+                  className="cursor-pointer hover:underline inline uppercase text-sm text-ellipsis whitespace-nowrap overflow-hidden"
+                >
+                  {a.name}{i < track.artists.length - 1 ? ", " : ""}
+                </h2>
+              </Link>
             )}
           </div>
         </div>

--- a/frontend/src/components/Profile/FavouriteArtists.tsx
+++ b/frontend/src/components/Profile/FavouriteArtists.tsx
@@ -1,7 +1,7 @@
 import type { FC } from "react"
 import { confirmAlert } from "react-confirm-alert"
 import { ImBin2 } from "react-icons/im"
-import { useNavigate } from "react-router-dom"
+import { Link, useNavigate } from "react-router-dom"
 import { toast } from "react-toastify"
 
 import type Artist from "../../interfaces/Artist"
@@ -99,12 +99,13 @@ const FavouriteArtists : FC<{
             key={a.id}
             className="ml-0.5 bg-gray-300/30 px-2 py-0.5 rounded m-0.5"
           >
-            <span
-              onClick={() => navigate("/explore/tracks", { state: { redirectArtist: a.name } })}
-              className="cursor-pointer hover:underline"
+            <Link
+              to="/explore/tracks"
+              state={{ redirectArtist: a.name }}
+              className="hover:underline"
             >
               {a.name}
-            </span>
+            </Link>
             <ImBin2
               onClick={() => confirmRemove(a.id, a.name)}
               title="Remove"

--- a/frontend/src/components/Profile/FavouriteGenres.tsx
+++ b/frontend/src/components/Profile/FavouriteGenres.tsx
@@ -1,7 +1,7 @@
 import type { FC } from "react"
 import { confirmAlert } from "react-confirm-alert"
 import { ImBin2 } from "react-icons/im"
-import { useNavigate } from "react-router-dom"
+import { Link, useNavigate } from "react-router-dom"
 import { toast } from "react-toastify"
 
 import type User from "../../interfaces/User"
@@ -95,12 +95,13 @@ const FavouriteGenres : FC<{
       <div className="w-2/3 mt-2 flex flex-wrap justify-center items-center">
         {list.map(g =>
           <div key={g} className="ml-0.5 bg-gray-300/30 px-2 py-0.5 rounded m-0.5">
-            <span
-              onClick={() => navigate("/explore/tracks", { state: { redirectGenre: g } })}
-              className="cursor-pointer hover:underline"
+            <Link
+              to="/explore/tracks"
+              state={{ redirectGenre: g }}
+              className="hover:underline"
             >
               {g}
-            </span>
+            </Link>
             <ImBin2
               onClick={() => confirmRemove(g)}
               title="Remove"

--- a/frontend/src/components/SideContent.tsx
+++ b/frontend/src/components/SideContent.tsx
@@ -19,10 +19,10 @@ const SideContent : FC = () => {
   return (
     <div className="w-full h-full border border-white/20 rounded-md flex flex-col justify-between text-center py-6">
 
-      <div className="">
+      <Link to="/home">
         <h1 className="text-6xl font-bold -skew-y-3 bg-spotify-green pb-1">SNM</h1>
         <h3 className="-skew-y-3 text-lg font-bold">Social Network for Music</h3>
-      </div>
+      </Link>
 
       <div className="">
         {links.map(l =>

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -28,7 +28,7 @@ const Profile : FC = () => {
         const { valid, message } = checkTokenExpiration()
         if (!valid) {
           toast.error(message)
-          navigate("/login")
+          navigate("/login", { replace: true })
           return
         }
 


### PR DESCRIPTION
- replace `navigate` with `Link` where possible


Various:
- add link to logo in `SideContent`
- fix redirect on token error in `Profile`
- fix crash if `track.images` empty